### PR TITLE
Update bspm_version

### DIFF
--- a/playbooks/group_vars/rstudio
+++ b/playbooks/group_vars/rstudio
@@ -1,4 +1,4 @@
-    bspm_version: bspm_0.3.7
+    bspm_version: bspm_0.3.8
     rstudio_version: rstudio-server-1.4.1106-amd64
     rstudio_pro_version: rstudio-server-pro-1.4.1106-4-amd64
     python_base_dir: 3.7-base


### PR DESCRIPTION
this resulted in https://cloud.r-project.org/src/contrib/bspm_0.3.7.tar.gz which does not exist, changed it to 0.3.8