### PR TITLE
install latest r (curr. 4.1.1) from conda-forge instead of r (3.6.3)

### DIFF
--- a/playbooks/jupyterhub.yml
+++ b/playbooks/jupyterhub.yml
@@ -36,7 +36,7 @@
         executable: /bin/bash
 
     - name: install r kernel
-      shell: source /opt/tljh/user/bin/activate && conda install --yes --quiet --channel r r-essentials
+      shell: source /opt/tljh/user/bin/activate && conda install --yes --quiet --channel conda-forge r-essentials
       args:
         executable: /bin/bash
 


### PR DESCRIPTION
conda-forge channel contains newer versions than -c r