### PR TITLE
added additional repo for libgit2 for r usethis package via bpsm

### DIFF
--- a/playbooks/roles/workspace/tasks/main.yml
+++ b/playbooks/roles/workspace/tasks/main.yml
@@ -25,6 +25,11 @@
     repo: "ppa:cran/poppler"
     state: present
 
+- name: add different repository for libgit2
+  apt_repository:
+    repo: "ppa:cran/libgit2"
+    state: present
+
 - name: install common dependencies
   apt:
     pkg:


### PR DESCRIPTION
add-apt-repository ppa:cran/libgit2
 PPA with backport of libgit2 that does not depend on libcurl4-gnutls-dev
 More info: https://launchpad.net/~cran/+archive/ubuntu/libgit2

==
commit in order to make usethis installation work with bspm enabled.

adding repo makes "r-cran-gert" work (requires libgit2-26+) which is a dependency of usethis

required libgit2 package not available in current repositories
==
to test:
install.packages("usethis") in R console
